### PR TITLE
Helmet deaden sound

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -98,7 +98,7 @@
 
 /mob/living/carbon/human/playsound_local(turf/turf_source, soundin, vol, vary, frequency, falloff, is_global, channel, sound/S)
 	if(istype(head, /obj/item/clothing/head/helmet))
-		vol = vol * 0.5
+		vol = vol * 0.4 //helmets block most of the sound
 	. = ..()
 	
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -96,6 +96,12 @@
 		return FALSE
 	return ..()
 
+/mob/living/carbon/human/playsound_local(turf/turf_source, soundin, vol, vary, frequency, falloff, is_global, channel, sound/S)
+	if(istype(head, /obj/item/clothing/head/helmet))
+		vol = vol * 0.5
+	. = ..()
+	
+
 /proc/open_sound_channel()
 	var/static/next_channel = 1	//loop through the available 1024 - (the ones we reserve) channels and pray that its not still being used
 	. = ++next_channel


### PR DESCRIPTION
## About The Pull Request

Helmets now deaden sound to the player when worn.

This isn't ideal because it affects all sounds at the moment, and presumably 'in the ear' sounds should still be full volume. i.e. radio chatter/static

but that's a problem for future people to puzzle out!

## Why It's Good For The Game

helmets reduce the volume of sounds to 40% of actual if you are wearing a helmet.

## Changelog
:cl: Hughgent
add: Helmets deaden sounds when worn.
/:cl:
